### PR TITLE
Daisuki Scrapper using REST API

### DIFF
--- a/src/services/stream/daisuki.py
+++ b/src/services/stream/daisuki.py
@@ -7,27 +7,58 @@ from datetime import datetime
 from .. import AbstractServiceHandler
 from data.models import Episode
 
+import re
+
 class ServiceHandler(AbstractServiceHandler):
+	_api_show_url = "https://motto.daisuki.net/api2/seriesdetail/{id}"
+	_episode_url = "http://www.daisuki.net/anime/watch.{show}.{ep}.html"
+	_show_url = "http://www.daisuki.net/anime/detail.{show}.html"
+	_show_re = re.compile("daisuki.net/anime/detail.([\w-]+)", re.I)
+
 	def __init__(self):
 		super().__init__("daisuki", "Daisuki", False)
-	
+
 	# Episode finding
-	
+
 	def get_all_episodes(self, stream, **kwargs):
-		return []
-	
+		info("Getting episodes for Daisuki/{}".format(stream.show_id))
+
+		episodes = []
+		response = self.request(url, xml=True, **kwargs)
+
+		for movieset in response.findall("movieset"):
+			for items in movieset.findall("items"):
+				for item in items.findall("item"):
+                	episodes.append(Episode(item.get("chapter"), None, _episode_url.format(show=stream.show_key, ep=item.get("productid")), datetime.utcnow()))
+
+		return episodes
+
 	# Remote info getting
-	
+
 	def get_stream_info(self, stream, **kwargs):
-		return None
-	
+		info("Getting stream info for Daisuki/{}".format(stream.show_id))
+
+		url = _api_show_url.format(id=stream.show_id)
+		response = self.request(url, xml=True, **kwargs)
+		if response is None:
+			error("Cannot get feed")
+			return None
+
+		stream.name = response.get("result").get("abstruct").get("title")
+		return stream
+
 	def get_seasonal_streams(self, year=None, season=None, **kwargs):
+		# Seasonal streams are not supported by Daisuki
 		return list()
-	
+
 	# Local info formatting
-	
+
 	def get_stream_link(self, stream):
-		return None
-	
+		# Just going to assume it's the correct service
+		return self._show_url.format(show=stream.show_key)
+
 	def extract_show_key(self, url):
+		match = self._show_re.search(url)
+		if match:
+			return match.group(1)
 		return None


### PR DESCRIPTION
There you go. Daisuki scrapper, using their REST API.

The web page has more reliable information, but this should do the trick

The only issue we cannot get the show key from the REST API, and using the show id doesn't work for stream. I used stream.show_id but I'm not sure this is what it is meant for. Daisuki bot from Shadowfix used separate DaisukiURL (for show URL) and API URL
