### PR TITLE
Update nyaa service

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -19,7 +19,7 @@ password =
 client = 
 
 [service.nyaa]
-domain = nyaa.se
+domain = nyaa.si
 excluded_users = 
 filter = 2
 

--- a/src/services/stream/nyaa.py
+++ b/src/services/stream/nyaa.py
@@ -10,7 +10,7 @@ from .. import AbstractServiceHandler
 from data.models import Episode
 
 class ServiceHandler(AbstractServiceHandler):
-	_search_base = "https://{domain}/?page=rss&cats=1_37&filter={filter}&term={q}&exclude={excludes}"
+	_search_base = "https://{domain}/?page=rss&c=1_2&f={filter}&q={q}&exclude={excludes}"
 	
 	def __init__(self):
 		super().__init__("nyaa", "Nyaa", True)
@@ -53,7 +53,7 @@ class ServiceHandler(AbstractServiceHandler):
 		debug("  query={}".format(query))
 		query = url_quote(query, safe="", errors="ignore")
 		
-		domain = self.config.get("domain", "nyaa.se")
+		domain = self.config.get("domain", "nyaa.si")
 		filter_ = self.config.get("filter", "2")
 		excludes = self.config.get("excluded_users", "").replace(" ", "")
 		url = self._search_base.format(domain=domain, filter=filter_, excludes=excludes, q=query)


### PR DESCRIPTION
Updates the nyaa service to check `nyaa.si` instead of `nyaa.se`. Just noticed it never got updated last season :(

RSS feed checks Trusted sources `f=2` from English-translated torrents `c=1_2` using `q={q}` as the search parameter. Not sure if .si has support for excludes but I don't want to take it out if it does actually work (or ends up working later on).

Ran the bot and it managed to find and post an episode from nyaa so it should be all good.