### PR TITLE
Add Fall 2017 config

### DIFF
--- a/season_configs/fall_2017.yaml
+++ b/season_configs/fall_2017.yaml
@@ -1,0 +1,530 @@
+---
+title: 'Mahoutsukai no Yome'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12942'
+  anilist: 'https://anilist.co/anime/98436/MahoutsukainoYome'
+  mal: 'https://myanimelist.net/anime/35062/Mahoutsukai_no_Yome'
+streams:
+  crunchyroll: ''
+---
+title: 'Kekkai Sensen & Beyond'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12571'
+  anilist: 'https://anilist.co/anime/97886/KekkaiSensenBeyond'
+  mal: 'https://myanimelist.net/anime/34451/Kekkai_Sensen___Beyond'
+streams:
+  crunchyroll: ''
+---
+title: 'Dies irae'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=11204'
+  anilist: 'https://anilist.co/anime/21555/Diesirae'
+  mal: 'https://myanimelist.net/anime/32271/Dies_Irae'
+streams:
+  crunchyroll: ''
+---
+title: 'Shokugeki no Souma: San no Sara'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13244'
+  anilist: 'https://anilist.co/anime/99255/ShokugekinoSoumaSannoSara'
+  mal: 'https://myanimelist.net/anime/35788/Shokugeki_no_Souma__San_no_Sara'
+streams:
+  crunchyroll: ''
+---
+title: 'Black Clover'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12665'
+  anilist: 'https://anilist.co/anime/97940/BlackClover'
+  mal: 'https://myanimelist.net/anime/34572/Black_Clover_TV'
+streams:
+  crunchyroll: ''
+---
+title: 'Inuyashiki'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12653'
+  anilist: 'https://anilist.co/anime/97922/Inuyashiki'
+  mal: 'https://myanimelist.net/anime/34542/Inuyashiki'
+streams:
+  crunchyroll: ''
+---
+title: 'Himouto! Umaru-chan R'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13106'
+  anilist: 'https://anilist.co/anime/98572/HimoutoUmaruchanR'
+  mal: 'https://myanimelist.net/anime/35376/Himouto_Umaru-chan_R'
+streams:
+  crunchyroll: ''
+---
+title: 'Kino no Tabi: The Beautiful World - The Animated Series'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12959'
+  anilist: 'https://anilist.co/anime/98448/KinonoTabiTheBeautifulWorldtheAnimatedSeries'
+  mal: 'https://myanimelist.net/anime/35079/Kino_no_Tabi__The_Beautiful_World_-_The_Animated_Series'
+streams:
+  crunchyroll: ''
+---
+title: 'Just Because!'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13199'
+  anilist: 'https://anilist.co/anime/98820/JustBecause'
+  mal: 'https://myanimelist.net/anime/35639/Just_Because'
+streams:
+  crunchyroll: ''
+---
+title: 'UQ Holder!: Mahou Sensei Negima! 2'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12227'
+  anilist: 'https://anilist.co/anime/21855/UQHolderMahouSenseiNegima2'
+  mal: 'https://myanimelist.net/anime/33478/UQ_Holder__Mahou_Sensei_Negima_2'
+streams:
+  crunchyroll: ''
+---
+title: '3-gatsu no Lion 2nd Season'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12994'
+  anilist: 'https://anilist.co/anime/98478/3gatsunoLion2'
+  mal: 'https://myanimelist.net/anime/35180/3-gatsu_no_Lion_2nd_Season'
+streams:
+  crunchyroll: ''
+---
+title: 'Kujira no Kora wa Sajou ni Utau'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12712'
+  anilist: 'https://anilist.co/anime/98449/KujiranoKorawaSajouniUtau'
+  mal: 'https://myanimelist.net/anime/34712/Kujira_no_Kora_wa_Sajou_ni_Utau'
+streams:
+  crunchyroll: ''
+---
+title: 'Boku no Kanojo ga Majime Sugiru Shojo Bitch na Ken'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13217'
+  anilist: 'https://anilist.co/anime/98951/BokunoKanojogaMajimeSugiruShojoBitchnaKen'
+  mal: 'https://myanimelist.net/anime/35712/Boku_no_Kanojo_ga_Majimesugiru_Sho-bitch_na_Ken'
+streams:
+  crunchyroll: ''
+---
+title: 'Love Live! Sunshine!! 2'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12897'
+  anilist: 'https://anilist.co/anime/98349/LoveLiveSunshine2'
+  mal: 'https://myanimelist.net/anime/34973/Love_Live_Sunshine_2nd_Season'
+streams:
+  crunchyroll: ''
+---
+title: 'Juuni Taisen'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12956'
+  anilist: 'https://anilist.co/anime/98443/JuuniTaisen'
+  mal: 'https://myanimelist.net/anime/35076/Juuni_Taisen'
+streams:
+  crunchyroll: ''
+---
+title: 'Yuuki Yuuna wa Yuusha de Aru: Washio Sumi no Shou'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12501'
+  anilist: 'https://anilist.co/anime/97769/YuukiYuunawaYuushadeAruYuushanoShou'
+  mal: 'https://myanimelist.net/anime/34284/Yuuki_Yuuna_wa_Yuusha_de_Aru__Washio_Sumi_no_Shou'
+streams:
+  crunchyroll: ''
+---
+title: 'Yuuki Yuuna wa Yuusha de Aru: Yuusha no Shou'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12500'
+  anilist: 'https://anilist.co/anime/97769/YuukiYuunawaYuushadeAruYuushanoShou'
+  mal: 'https://myanimelist.net/anime/34445/Yuuki_Yuuna_wa_Yuusha_de_Aru__Yuusha_no_Shou'
+streams:
+  crunchyroll: ''
+---
+title: 'Dia Horizon'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13311'
+  anilist: 'https://anilist.co/anime/99636/DiaHorizon'
+  mal: 'https://myanimelist.net/anime/35999/Dia_Horizon'
+streams:
+  crunchyroll: ''
+---
+title: 'Imouto sae Ireba Ii.'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=11352'
+  anilist: 'https://anilist.co/anime/98596/ImoutosaeIrebaIi'
+  mal: 'https://myanimelist.net/anime/35413/Imouto_sae_Ireba_Ii'
+streams:
+  crunchyroll: ''
+---
+title: 'Saredo Tsumibito wa Ryuu to Odoru'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12337'
+  anilist: 'https://anilist.co/anime/87504/SaredoTsumibitowaRyuutoOdoru'
+  mal: 'https://myanimelist.net/anime/33889/Saredo_Tsumibito_wa_Ryuu_to_Odoru'
+streams:
+  crunchyroll: ''
+---
+title: 'Ousama Game The Animation'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13335'
+  anilist: 'https://anilist.co/anime/99698/OusamaGameTheAnimation'
+  mal: 'https://myanimelist.net/anime/36027/Ousama_Game_The_Animation'
+streams:
+  crunchyroll: ''
+---
+title: 'Houseki no Kuni'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13165'
+  anilist: 'https://anilist.co/anime/98707/HousekinoKuni'
+  mal: 'https://myanimelist.net/anime/35557/Houseki_no_Kuni_TV'
+streams:
+  crunchyroll: ''
+---
+title: 'Code:Realize - Sousei no Himegimi'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=11516'
+  anilist: 'https://anilist.co/anime/98630/CodeRealizeSouseinoHimegimi'
+  mal: 'https://myanimelist.net/anime/31456/Code_Realize__Sousei_no_Himegimi'
+streams:
+  crunchyroll: ''
+---
+title: 'Shoujo Shuumatsu Ryokou'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13256'
+  anilist: 'https://anilist.co/anime/99420/ShoujoShuumatsuRyokou'
+  mal: 'https://myanimelist.net/anime/35838/Shoujo_Shuumatsu_Ryokou'
+streams:
+  crunchyroll: ''
+---
+title: 'Hoozuki no Reitetsu 2nd Season'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12954'
+  anilist: 'https://anilist.co/anime/98438/HoozukinoReitetsu2'
+  mal: 'https://myanimelist.net/anime/35075/Hoozuki_no_Reitetsu_2nd_Season'
+streams:
+  crunchyroll: ''
+---
+title: 'Blend S'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12694'
+  anilist: 'https://anilist.co/anime/97994/BlendS'
+  mal: 'https://myanimelist.net/anime/34618/Blend_S'
+streams:
+  crunchyroll: ''
+---
+title: 'Net-juu no Susume'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13345'
+  anilist: 'https://anilist.co/anime/99726/NetjuunoSusume'
+  mal: 'https://myanimelist.net/anime/36038/Net-juu_no_Susume'
+streams:
+  crunchyroll: ''
+---
+title: 'Konohana Kitan'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13030'
+  anilist: 'https://anilist.co/anime/98506/KonohanaKitan'
+  mal: 'https://myanimelist.net/anime/35241/Konohana_Kitan'
+streams:
+  crunchyroll: ''
+---
+title: 'Osomatsu-san 2'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12944'
+  anilist: 'https://anilist.co/anime/98565'
+  mal: 'https://myanimelist.net/anime/35067/Osomatsu-san_2'
+streams:
+  crunchyroll: ''
+---
+title: 'Garo: Vanishing Line'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13390'
+  anilist: 'https://anilist.co/anime/99796/GAROVANISHINGLINE'
+  mal: 'https://myanimelist.net/anime/36144/Vanishing_Line'
+streams:
+  crunchyroll: ''
+---
+title: 'Gintama. (2017)'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12419'
+  anilist: 'https://anilist.co/anime/99714/GintamaShinsaku'
+  mal: 'https://myanimelist.net/anime/35843/Gintama_2017'
+streams:
+  crunchyroll: ''
+---
+title: 'Anime-Gataris'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13114'
+  anilist: 'https://anilist.co/anime/98607/AnimeGataris'
+  mal: 'https://myanimelist.net/anime/35427/Animegataris'
+streams:
+  crunchyroll: ''
+---
+title: 'Two Car'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13322'
+  anilist: 'https://anilist.co/anime/99672/TwoCar'
+  mal: 'https://myanimelist.net/anime/36009/Two_Car'
+streams:
+  crunchyroll: ''
+---
+title: 'Tsukipro The Animation'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12578'
+  anilist: 'https://anilist.co/anime/97904/TSUKIPROTHEANIMATION'
+  mal: 'https://myanimelist.net/anime/34474/Tsukipro_The_Animation'
+streams:
+  crunchyroll: ''
+---
+title: 'Sengoku Night Blood'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13036'
+  anilist: 'https://anilist.co/anime/98603/SengokuNightBlood'
+  mal: 'https://myanimelist.net/anime/35251/Sengoku_Night_Blood'
+streams:
+  crunchyroll: ''
+---
+title: 'Robomasters The Animated Series'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12815'
+  anilist: 'https://anilist.co/anime/98526/RobomastersTheAnimatedSeries'
+  mal: 'https://myanimelist.net/anime/34903/RoboMasters_the_Animated_Series'
+streams:
+  crunchyroll: ''
+---
+title: 'The iDOLM@STER Side M'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12820'
+  anilist: 'https://anilist.co/anime/98310/TheIdolmsterSideM'
+  mal: 'https://myanimelist.net/anime/34915/The_iDOLMSTER_Side_M'
+streams:
+  crunchyroll: ''
+---
+title: 'Urahara'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13035'
+  anilist: 'https://anilist.co/anime/98513/URAHARA'
+  mal: 'https://myanimelist.net/anime/35250/Urahara'
+streams:
+  crunchyroll: ''
+---
+title: 'Itsudatte Bokura no Koi wa 10 Centi Datta.'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13038'
+  anilist: 'https://anilist.co/anime/98977/ItsudatteBokuranoKoiwa10cmdatta'
+  mal: 'https://myanimelist.net/anime/36220/Itsudatte_Bokura_no_Koi_wa_10_Centi_Datta'
+streams:
+  crunchyroll: ''
+---
+title: 'Infini-T Force'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12034'
+  anilist: 'https://anilist.co/anime/21756'
+  mal: 'https://myanimelist.net/anime/33027/Infini-T_Forc'
+streams:
+  crunchyroll: ''
+---
+title: 'Wake Up, Girls! Shin Shou'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12625'
+  anilist: 'https://anilist.co/anime/97933/WakeUpGirlsShinShou'
+  mal: 'https://myanimelist.net/anime/34522/Wake_Up_Girls_Shin_Shou'
+streams:
+  crunchyroll: ''
+---
+title: 'ClassicaLoid 2nd Season'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13069'
+  anilist: 'https://anilist.co/anime/98546/ClassicaLoid2'
+  mal: 'https://myanimelist.net/anime/35334/ClassicaLoid_2nd_Season'
+streams:
+  crunchyroll: ''
+---
+title: 'Dynamic Chord'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12731'
+  anilist: 'https://anilist.co/anime/98108/DYNAMICCHORD'
+  mal: 'https://myanimelist.net/anime/34771/Dynamic_Chord'
+streams:
+  crunchyroll: ''
+---
+title: 'Time Bokan: Gyakushuu no San-Okunin'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13039'
+  anilist: 'https://anilist.co/anime/98521/TimeBokanGyakushuunoSanOkunin'
+  mal: 'https://myanimelist.net/anime/35254/Time_Bokan__Gyakushuu_no_San_Akuni'
+streams:
+  crunchyroll: ''
+---
+title: 'Cardfight!! Vanguard G: Z'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13329'
+  anilist: 'https://anilist.co/anime/99733/CardfightVanguardGZ'
+  mal: 'https://myanimelist.net/anime/36022/Cardfight_Vanguard_G__Z'
+streams:
+  crunchyroll: ''
+---
+title: 'Osake wa Fuufu ni Natte kara'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13147'
+  anilist: 'https://anilist.co/anime/98657/OsakewaFuufuniNatteKara'
+  mal: 'https://myanimelist.net/anime/35484/Osake_wa_Fuufu_ni_Natte_kara'
+streams:
+  crunchyroll: ''
+---
+title: 'Omiai Aite wa Oshiego, Tsuyoki na, Mondaiji.'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13402'
+  anilist: 'https://anilist.co/anime/99894/OmiaiAitewaOshiegoTsuyokinaMondaiji'
+  mal: 'https://myanimelist.net/anime/36198/Omiai_Aite_wa_Oshiego_Tsuyokina_Mondaiji'
+streams:
+  crunchyroll: ''
+---
+title: 'Taishou Chicchai-san'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12557'
+  anilist: 'https://anilist.co/anime/97876/TaishouChicchaisan'
+  mal: 'https://myanimelist.net/anime/34411/Taishou_Chicchai-san'
+streams:
+  crunchyroll: ''
+---
+title: 'Cinderella Girls Gekijou 2nd Season'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13274'
+  anilist: 'https://anilist.co/anime/99742/CinderellaGirlsGekijou2ndSeason'
+  mal: 'https://myanimelist.net/anime/35883/Cinderella_Girls_Gekijou_2nd_Season'
+streams:
+  crunchyroll: ''
+---
+title: 'Pingu in the City'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13421'
+  anilist: 'https://anilist.co/anime/99994/PinguintheCity'
+  mal: ''
+streams:
+  crunchyroll: ''
+---
+title: 'Love Kome: We Love Rice 2nd Season'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13249'
+  anilist: 'https://anilist.co/anime/99391/LoveKomeWeLoveRice2'
+  mal: 'https://myanimelist.net/anime/35818/Love_Kome__We_Love_Rice_2nd_Season'
+streams:
+  crunchyroll: ''
+---
+title: 'Oretacha Youkai Ningen'
+type: tv
+has_source: false
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13389'
+  anilist: 'https://anilist.co/anime/99856/OretachaYoukaiNingen'
+  mal: 'https://myanimelist.net/anime/36135/Oretacha_Youkai_Ningen'
+streams:
+  crunchyroll: ''
+---
+title: 'Ame-iro Cocoa Series: Ame-con!!'
+type: tv
+has_source: true
+info:
+  anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=13282'
+  anilist: 'https://anilist.co/anime/99741/Amecon'
+  mal: 'https://myanimelist.net/anime/35923/Ame-iro_Cocoa_Series__Ame-co'
+streams:
+  crunchyroll: ''


### PR DESCRIPTION
Like previous seasons I've just gone off what AniChart has listed for next season. 

Things that might cause isuses:

- No idea how Gintama's naming scheme works. MAL and AniDB list it as `Gintama. (2017)` even though `Gintama.` aired this year anyway :/

- Split up the two Yuuki Yuuna entries (AniChart counts it as  one 12 episode entry, AniDB and MAL list two 6 episode entries. )

- MAL doesn't have an entry for `Pingu in the City` so I left that blank